### PR TITLE
Allow a single operand for $in, $nin and $and

### DIFF
--- a/lib/JsonFilterOperator.js
+++ b/lib/JsonFilterOperator.js
@@ -274,7 +274,7 @@ JsonFilterOperator.defaults = {
 
     $in: {
         operandsType: "array",
-        operandsCountMin: 2,
+        operandsCountMin: 1,
         match: function (context, operands, document, operators) {
             if (!Array.isArray(context)) {
                 context = [context];
@@ -291,7 +291,7 @@ JsonFilterOperator.defaults = {
     },
     $nin: {
         operandsType: "array",
-        operandsCountMin: 2,
+        operandsCountMin: 1,
         match: function (context, operands, document, operators) {
             if (!Array.isArray(context)) {
                 context = [context];
@@ -308,7 +308,7 @@ JsonFilterOperator.defaults = {
     },
     $all: {
         operandsType: "array",
-        operandsCountMin: 2,
+        operandsCountMin: 1,
         match: function (context, operands, document, operators) {
             if (!Array.isArray(context)) {
                 context = [context];


### PR DESCRIPTION
Hi,

I updated the $in, $nin and $all operators to allow for a single operand.

The main reason is allow criteria such as:
```
{
  tag: ["experiment1"]
}
```

Really liked the design that allowed a clean update.